### PR TITLE
Update Nano Banana to Nano banana pro with gemini-3-pro-image-preview

### DIFF
--- a/app/api/prompts/enhance/route.ts
+++ b/app/api/prompts/enhance/route.ts
@@ -85,11 +85,11 @@ Enhance this for an image-to-video workflow (inspired by Veo best practices):
 - If audio ambiance is desired, mention it briefly; otherwise omit
 
 Return ONLY the enhanced video prompt.`
-      } else if (modelId === 'gemini-nano-banana') {
+      } else if (modelId === 'gemini-nano-banana-pro') {
         requestContent = `User wants to edit an image. Their instruction: "${prompt}"
 Reference image will be provided.
 
-IMPORTANT: For Nano Banana image editing:
+IMPORTANT: For Nano banana pro image editing:
 - Describe ONLY the specific changes to make
 - Use precise, action-oriented language
 - Reference the provided image as "the provided image" or "this image"

--- a/components/generation/ModelPicker.tsx
+++ b/components/generation/ModelPicker.tsx
@@ -31,7 +31,7 @@ export function ModelPicker({
   generationType,
 }: ModelPickerProps) {
   const [open, setOpen] = useState(false)
-  const [pinnedModels, setPinnedModels] = useState<string[]>(['gemini-nano-banana'])
+  const [pinnedModels, setPinnedModels] = useState<string[]>(['gemini-nano-banana-pro'])
   const [models, setModels] = useState<Model[]>([])
   const [loading, setLoading] = useState(true)
 

--- a/lib/models/adapters/gemini.ts
+++ b/lib/models/adapters/gemini.ts
@@ -2,7 +2,7 @@ import { BaseModelAdapter, GenerationRequest, GenerationResponse, ModelConfig } 
 
 /**
  * Google Gemini API Adapter
- * Supports Gemini 2.5 Flash Image (Nano Banana) and Veo 3.1
+ * Supports Gemini 3 Pro Image (Nano banana pro) and Veo 3.1
  */
 
 export class GeminiAdapter extends BaseModelAdapter {
@@ -37,11 +37,11 @@ export class GeminiAdapter extends BaseModelAdapter {
   }
 
   private async generateImage(request: GenerationRequest): Promise<GenerationResponse> {
-    console.log('Nano Banana: Starting image generation')
-    console.log('Nano Banana: Prompt:', request.prompt)
-    console.log('Nano Banana: Has reference image:', !!request.referenceImage)
-    // Gemini 2.5 Flash Image (Nano Banana) endpoint
-    const endpoint = `${this.baseUrl}/models/gemini-2.5-flash-image:generateContent`
+    console.log('Nano banana pro: Starting image generation')
+    console.log('Nano banana pro: Prompt:', request.prompt)
+    console.log('Nano banana pro: Has reference image:', !!request.referenceImage)
+    // Gemini 3 Pro Image (Nano banana pro) endpoint
+    const endpoint = `${this.baseUrl}/models/gemini-3-pro-image-preview:generateContent`
 
     const numImages = request.numOutputs || 1
     
@@ -116,7 +116,7 @@ export class GeminiAdapter extends BaseModelAdapter {
       }
     }
 
-    console.log('Nano Banana: Sending request to Gemini API')
+    console.log('Nano banana pro: Sending request to Gemini API')
     const response = await fetch(`${endpoint}?key=${this.apiKey}`, {
       method: 'POST',
       headers: {
@@ -125,7 +125,7 @@ export class GeminiAdapter extends BaseModelAdapter {
       body: JSON.stringify(payload),
     })
 
-    console.log('Nano Banana: Response status:', response.status)
+    console.log('Nano banana pro: Response status:', response.status)
 
     if (!response.ok) {
       const error = await response.json()
@@ -134,7 +134,7 @@ export class GeminiAdapter extends BaseModelAdapter {
       throw new Error(error.error?.message || 'Image generation failed')
     }
     
-    console.log('Nano Banana: Response OK, parsing data')
+    console.log('Nano banana pro: Response OK, parsing data')
 
     const data = await response.json()
 
@@ -467,11 +467,11 @@ export class GeminiAdapter extends BaseModelAdapter {
 // Model configurations based on official Gemini API docs
 // https://ai.google.dev/gemini-api/docs/image-generation
 export const NANO_BANANA_CONFIG: ModelConfig = {
-  id: 'gemini-nano-banana',
-  name: 'Nano Banana',
+  id: 'gemini-nano-banana-pro',
+  name: 'Nano banana pro',
   provider: 'Google',
   type: 'image',
-  description: 'Gemini 2.5 Flash Image - Highly effective and precise image generation',
+  description: 'Gemini 3 Pro Image - Advanced image generation with superior quality',
   maxResolution: 1536, // Max dimension from 21:9 (1536x672)
   defaultAspectRatio: '1:1',
   // All 10 supported aspect ratios from official Gemini API documentation

--- a/store/uiStore.ts
+++ b/store/uiStore.ts
@@ -31,7 +31,7 @@ export const useUIStore = create<UIState>()(
     persist(
       (set) => ({
         // Initial state
-        selectedModel: 'gemini-nano-banana',
+        selectedModel: 'gemini-nano-banana-pro',
         parameters: defaultParameters,
 
         // Actions


### PR DESCRIPTION
- Change API endpoint from gemini-2.5-flash-image to gemini-3-pro-image-preview
- Rename model from "Nano Banana" to "Nano banana pro"
- Update model ID from gemini-nano-banana to gemini-nano-banana-pro
- Update default selected model and pinned models in UI