### PR TITLE
feat(cmf): multi-product import UX, clown-aware prompts, source-template PDF

### DIFF
--- a/src/app/api/cmf/import/route.ts
+++ b/src/app/api/cmf/import/route.ts
@@ -13,6 +13,7 @@ import {
   logCmfActivity,
   requireAuthenticatedProfile,
 } from '@/lib/cmf/service'
+import { getCmfProduct } from '@/lib/cmf/products'
 import { createRateLimiter } from '@/lib/api/rate-limit'
 
 export const dynamic = 'force-dynamic'
@@ -183,15 +184,23 @@ export async function POST(request: NextRequest) {
       format: parsed.format,
       unmappedSheets: parsed.format === 'transposed' ? parsed.unmappedSheets : [],
     },
-    /** All packets created by this import — one per product slug. */
-    packets: packets.map(({ packet, renders }) => ({
-      id: packet.id,
-      name: packet.name,
-      cmfCode: packet.cmfCode,
-      status: packet.status,
-      productSlug: renders[0]?.productSlug ?? null,
-      renderCount: renders.length,
-    })),
+    /** All packets created by this import — one per product slug.
+     * Each packet carries `productName` so the UI can say
+     * "Created 2 product packets: Switch 2, Cocoon" without
+     * re-deriving the display name from the slug. */
+    packets: packets.map(({ packet, renders }) => {
+      const productSlug = renders[0]?.productSlug ?? null
+      const productName = productSlug ? getCmfProduct(productSlug)?.name ?? null : null
+      return {
+        id: packet.id,
+        name: packet.name,
+        cmfCode: packet.cmfCode,
+        status: packet.status,
+        productSlug,
+        productName,
+        renderCount: renders.length,
+      }
+    }),
     /** Convenience: the packet the workspace should auto-open. */
     packet: primary
       ? {

--- a/src/app/api/cmf/packets/[id]/pdf/route.ts
+++ b/src/app/api/cmf/packets/[id]/pdf/route.ts
@@ -160,6 +160,8 @@ export async function POST(
       cmfCode: document.cmfCode,
       notes: document.notes,
       renders: renderProjections,
+      drawnBy: auth.profile.email ?? null,
+      isDraft: document.isDraft,
     })
 
     const firstPage = document.pages[0]

--- a/src/components/cmf/CmfImportPanel.tsx
+++ b/src/components/cmf/CmfImportPanel.tsx
@@ -6,10 +6,18 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { useImportCmfWorkbook } from '@/hooks/useCmf'
 import { useToast } from '@/components/ui/use-toast'
-import { Upload, Download, Loader2, AlertTriangle, CheckCircle2 } from 'lucide-react'
+import { Upload, Download, Loader2, AlertTriangle, CheckCircle2, Package } from 'lucide-react'
 
 interface CmfImportPanelProps {
   onPacketCreated?: (packetId: string) => void
+}
+
+interface CreatedPacketSummary {
+  id: string
+  name: string
+  productSlug: string | null
+  productName: string | null
+  renderCount: number
 }
 
 export function CmfImportPanel({ onPacketCreated }: CmfImportPanelProps) {
@@ -20,7 +28,10 @@ export function CmfImportPanel({ onPacketCreated }: CmfImportPanelProps) {
   const [errors, setErrors] = useState<
     Array<{ rowIndex: number; field?: string; message: string }>
   >([])
-  const [lastSuccess, setLastSuccess] = useState<{ rows: number } | null>(null)
+  const [lastSuccess, setLastSuccess] = useState<{
+    rows: number
+    packets: CreatedPacketSummary[]
+  } | null>(null)
   const importMutation = useImportCmfWorkbook()
   const { toast } = useToast()
 
@@ -39,22 +50,38 @@ export function CmfImportPanel({ onPacketCreated }: CmfImportPanelProps) {
         cmfCode: cmfCode || undefined,
         createPacket: true,
       })
-      const packetCount = result.packets?.length ?? (result.packet ? 1 : 0)
+      const createdPackets: CreatedPacketSummary[] = (result.packets ?? []).map((p) => ({
+        id: p.id,
+        name: p.name,
+        productSlug: p.productSlug,
+        productName: p.productName,
+        renderCount: p.renderCount,
+      }))
+      const packetCount = createdPackets.length || (result.packet ? 1 : 0)
+      // Compact "Switch 2, Cocoon" summary; falls back to packet name when
+      // the catalog doesn't know the slug (so we never silently lose info).
+      const productListLabel = createdPackets
+        .map((p) => p.productName ?? p.name)
+        .join(', ')
       const productSummary =
         packetCount > 1
-          ? ` across ${packetCount} product ${packetCount === 1 ? 'packet' : 'packets'}`
+          ? ` across ${packetCount} product packets`
           : ''
       if (result.import.errors.length > 0) {
         setErrors(result.import.errors)
+        setLastSuccess(null)
         toast({
           title: 'Import had warnings',
           description: `${result.import.rowCount} rows imported${productSummary}, ${result.import.errors.length} rows skipped`,
         })
       } else {
-        setLastSuccess({ rows: result.import.rowCount })
+        setLastSuccess({ rows: result.import.rowCount, packets: createdPackets })
         toast({
           title: 'Workbook imported',
-          description: `Created ${packetCount} ${packetCount === 1 ? 'packet' : 'packets'} from ${result.import.rowCount} rows`,
+          description:
+            packetCount > 1 && productListLabel
+              ? `Created ${packetCount} product packets: ${productListLabel}`
+              : `Created ${packetCount} ${packetCount === 1 ? 'packet' : 'packets'} from ${result.import.rowCount} rows`,
         })
       }
       if (result.packet?.id) {
@@ -146,11 +173,40 @@ export function CmfImportPanel({ onPacketCreated }: CmfImportPanelProps) {
       </div>
 
       {lastSuccess && (
-        <div className="flex items-start gap-2 rounded-md border border-emerald-500/40 bg-emerald-500/5 p-3 text-xs text-emerald-700 dark:text-emerald-200">
-          <CheckCircle2 className="h-4 w-4 flex-shrink-0 mt-0.5" />
-          <span>
-            Imported {lastSuccess.rows} {lastSuccess.rows === 1 ? 'row' : 'rows'} cleanly.
-          </span>
+        <div className="space-y-2 rounded-md border border-emerald-500/40 bg-emerald-500/5 p-3 text-xs text-emerald-700 dark:text-emerald-200">
+          <div className="flex items-start gap-2">
+            <CheckCircle2 className="h-4 w-4 flex-shrink-0 mt-0.5" />
+            <span>
+              Imported {lastSuccess.rows} {lastSuccess.rows === 1 ? 'row' : 'rows'} cleanly
+              {lastSuccess.packets.length > 1
+                ? ` into ${lastSuccess.packets.length} product packets.`
+                : '.'}
+            </span>
+          </div>
+          {lastSuccess.packets.length > 0 && (
+            <ul className="space-y-1 pl-6">
+              {lastSuccess.packets.map((p) => (
+                <li key={p.id} className="flex items-center gap-2">
+                  <Package className="h-3 w-3 flex-shrink-0 opacity-70" />
+                  <button
+                    type="button"
+                    onClick={() => onPacketCreated?.(p.id)}
+                    className="text-left underline-offset-2 hover:underline"
+                  >
+                    {p.productName ?? p.name}
+                  </button>
+                  <span className="text-emerald-700/70 dark:text-emerald-200/70">
+                    · {p.renderCount} {p.renderCount === 1 ? 'SKU' : 'SKUs'}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+          {lastSuccess.packets.length > 1 && (
+            <p className="pl-6 text-[11px] italic text-emerald-700/70 dark:text-emerald-200/70">
+              Each product becomes its own packet — click any to open it.
+            </p>
+          )}
         </div>
       )}
 

--- a/src/hooks/useCmf.ts
+++ b/src/hooks/useCmf.ts
@@ -186,6 +186,9 @@ export interface CmfImportResponse {
     cmfCode: string | null
     status: string
     productSlug: string | null
+    /** Display name resolved from the CMF product catalog. Null when the
+     * slug is unknown to the catalog (rare; would mean a parser bug). */
+    productName: string | null
     renderCount: number
   }>
   /** Convenience — the packet the workspace should auto-open. */

--- a/src/lib/cmf/pdf.ts
+++ b/src/lib/cmf/pdf.ts
@@ -1,46 +1,68 @@
 /**
  * CMF packet PDF builder (server-side, pdf-lib, no Node-only deps).
  *
- * Layout per page (16:9 page geometry, 1280×720 pt) — same proportions as the
- * source PowerPoint deck:
- *   ┌──────────────────────────── BANNER ────────────────────────────┐
- *   │  CMF code · Product · Date         Loop                       │
- *   ├────────────────────────────────────────────────────────────────┤
- *   │                            │                                   │
- *   │   Generated render image   │   Component spec table            │
- *   │   (left half)              │   Region · Pantone · Material    │
- *   │                            │                                   │
- *   ├────────────────────────────────────────────────────────────────┤
- *   │  Palette swatches                              Notes           │
- *   └────────────────────────────────────────────────────────────────┘
+ * The layout mirrors Damien's source template (Loop CMF deck). Each SKU
+ * produces two pages so the exported PDF drops straight into the existing
+ * approval / spec workflow without the team having to re-author it.
  *
- * Final page is a shared breakdown summarising every SKU in the packet
- * (palette grid + component matrix). For single-SKU packets the breakdown
- * page is omitted to keep the deliverable compact.
+ * Geometry: A4 portrait (595 × 842 pt). The previous landscape 16:9 layout
+ * was rebuilding the document instead of preserving Damien's template, so
+ * approved exports lost their familiar shape. We preserve the template
+ * structure here:
+ *
+ *   ┌─────────────────────────────────────────────────────────────┐
+ *   │  CMF number  │  Collection   │  Product name                │
+ *   │  Product code│  EAN code     │  Edit date                   │
+ *   │  Drawn       │  Checked      │  Checked                     │
+ *   ├─────────────────────────────────────────────────────────────┤
+ *   │                                       CMF Page 1            │
+ *   │  Product render                                              │
+ *   │  ┌─────────────────────────────────┐                         │
+ *   │  │                                 │                         │
+ *   │  │      generated render image      │   Component spec list  │
+ *   │  │                                 │                         │
+ *   │  └─────────────────────────────────┘                         │
+ *   │                                                              │
+ *   │  POM RING                                                    │
+ *   │    Material   POM                                            │
+ *   │    Finish     Matte                                          │
+ *   │    Colour     Pantone 7720C                                  │
+ *   │    Artwork    —                                              │
+ *   │  …                                                           │
+ *   └─────────────────────────────────────────────────────────────┘
+ *
+ * Page 2 is the part breakdown grid (component label + swatch chip per
+ * cell). For multi-SKU packets a final overview page lists every colourway
+ * in the pack so reviewers see the family at a glance.
  *
  * Why pdf-lib: pure JS, no Node addons, safe in Vercel Edge/Node runtimes.
  */
 
-import { PDFDocument, PDFFont, StandardFonts, rgb } from 'pdf-lib'
+import { PDFDocument, PDFFont, PDFPage, StandardFonts, rgb } from 'pdf-lib'
 import type { CmfRender } from '@prisma/client'
 import { getCmfProduct } from './products'
 import type { ComponentSpec, PaletteSwatch } from './schema'
 
-const PAGE_W = 1280
-const PAGE_H = 720
-const MARGIN = 48
-const BANNER_H = 80
-const FOOTER_H = 110
+// A4 portrait, matching Damien's source deck. Page-size constants live here
+// rather than imported from `document.ts` because that module still describes
+// the (legacy) 16:9 HTML preview; the PDF is the canonical surface for the
+// designer-facing template and must own its own geometry.
+const PAGE_W = 595
+const PAGE_H = 842
+const MARGIN = 36
+const HEADER_H = 96
+const FOOTER_H = 44
 
-// Loop-ish palette (purple primary in light mode, charcoal text), tuned to
-// stay legible on white pages.
 const COLOURS = {
   ink: rgb(0.07, 0.07, 0.08),
   muted: rgb(0.42, 0.42, 0.48),
   faint: rgb(0.86, 0.86, 0.9),
+  hairline: rgb(0.72, 0.72, 0.78),
   primary: rgb(0.36, 0.24, 0.74),
   swatchBorder: rgb(0.78, 0.78, 0.82),
-  bannerBg: rgb(0.96, 0.95, 0.92),
+  headerBg: rgb(0.97, 0.96, 0.93),
+  panelBg: rgb(0.97, 0.97, 0.98),
+  draft: rgb(0.95, 0.62, 0.18),
 }
 
 interface PdfFontPair {
@@ -73,7 +95,6 @@ async function embedRenderImage(pdf: PDFDocument, url: string | null) {
   if (!url) return null
   const bytes = await fetchImageBytes(url)
   if (!bytes) return null
-  // Try PNG first, fall back to JPG. pdf-lib will throw if the format does not match.
   try {
     return await pdf.embedPng(bytes)
   } catch {
@@ -86,7 +107,7 @@ async function embedRenderImage(pdf: PDFDocument, url: string | null) {
 }
 
 interface DrawTextArgs {
-  page: ReturnType<PDFDocument['addPage']>
+  page: PDFPage
   text: string
   x: number
   y: number
@@ -133,264 +154,615 @@ function drawWrappedText({
   return cursor
 }
 
-interface DrawBannerArgs {
-  page: ReturnType<PDFDocument['addPage']>
-  fonts: PdfFontPair
-  cmfCode: string
-  productName: string
-  colorwayName: string
-  generatedAt: Date
+/* ── Source-template meta header (3×3 grid) ─────────────────────────────── */
+
+interface MetaField {
+  label: string
+  value: string
 }
 
-function drawBanner({ page, fonts, cmfCode, productName, colorwayName, generatedAt }: DrawBannerArgs) {
+interface DrawHeaderArgs {
+  page: PDFPage
+  fonts: PdfFontPair
+  fields: MetaField[]
+  pageLabel: string
+  showDraftBadge?: boolean
+}
+
+/**
+ * Damien's template uses a top strip with nine identity fields arranged in
+ * a 3×3 grid (CMF number / Collection / Product name on top, then Product
+ * code / EAN / Edit date, then Drawn / Checked / Checked). We keep that
+ * shape so reviewers can scan it the same way they do in the source deck.
+ */
+function drawSourceHeader({ page, fonts, fields, pageLabel, showDraftBadge }: DrawHeaderArgs) {
+  // Background band
   page.drawRectangle({
     x: 0,
-    y: PAGE_H - BANNER_H,
+    y: PAGE_H - HEADER_H,
     width: PAGE_W,
-    height: BANNER_H,
-    color: COLOURS.bannerBg,
+    height: HEADER_H,
+    color: COLOURS.headerBg,
   })
   page.drawRectangle({
     x: 0,
-    y: PAGE_H - BANNER_H - 1,
+    y: PAGE_H - HEADER_H - 1,
     width: PAGE_W,
     height: 1,
-    color: COLOURS.faint,
+    color: COLOURS.hairline,
   })
 
-  page.drawText(cmfCode, {
-    x: MARGIN,
-    y: PAGE_H - 38,
-    size: 14,
-    font: fonts.bold,
-    color: COLOURS.ink,
-  })
-  page.drawText(productName, {
-    x: MARGIN,
-    y: PAGE_H - 60,
+  const gridX = MARGIN
+  const gridY = PAGE_H - 18
+  const cellW = (PAGE_W - MARGIN * 2) / 3
+  const rowH = (HEADER_H - 20) / 3
+
+  // Pad to exactly 9 cells so an under-filled packet still renders the grid
+  // (empty values land as em-dashes).
+  const padded = fields.slice(0, 9)
+  while (padded.length < 9) padded.push({ label: '', value: '' })
+
+  for (let i = 0; i < 9; i++) {
+    const row = Math.floor(i / 3)
+    const col = i % 3
+    const x = gridX + col * cellW
+    const y = gridY - row * rowH
+
+    const cell = padded[i]
+    if (cell.label) {
+      page.drawText(cell.label.toUpperCase(), {
+        x,
+        y,
+        size: 6,
+        font: fonts.bold,
+        color: COLOURS.muted,
+      })
+    }
+    if (cell.label || cell.value) {
+      page.drawText(cell.value || '—', {
+        x,
+        y: y - 10,
+        size: 9,
+        font: fonts.regular,
+        color: COLOURS.ink,
+        maxWidth: cellW - 8,
+      })
+    }
+  }
+
+  // Page label (right-aligned, primary colour — "CMF Page 1" / "Part Break
+  // Down Page 2" / "Pack Overview" in Damien's deck).
+  const labelWidth = fonts.bold.widthOfTextAtSize(pageLabel, 11)
+  page.drawText(pageLabel, {
+    x: PAGE_W - MARGIN - labelWidth,
+    y: PAGE_H - HEADER_H + 8,
     size: 11,
-    font: fonts.regular,
-    color: COLOURS.muted,
-  })
-
-  const colourwayLabel = colorwayName.toUpperCase()
-  const colourwayWidth = fonts.bold.widthOfTextAtSize(colourwayLabel, 16)
-  page.drawText(colourwayLabel, {
-    x: PAGE_W / 2 - colourwayWidth / 2,
-    y: PAGE_H - 45,
-    size: 16,
     font: fonts.bold,
     color: COLOURS.primary,
   })
 
-  const dateText = generatedAt.toISOString().slice(0, 10)
-  const dateWidth = fonts.mono.widthOfTextAtSize(dateText, 10)
-  page.drawText(dateText, {
-    x: PAGE_W - MARGIN - dateWidth,
-    y: PAGE_H - 38,
-    size: 10,
-    font: fonts.mono,
-    color: COLOURS.muted,
-  })
-
-  page.drawText('Loop · CMF', {
-    x: PAGE_W - MARGIN - fonts.bold.widthOfTextAtSize('Loop · CMF', 11),
-    y: PAGE_H - 60,
-    size: 11,
-    font: fonts.bold,
-    color: COLOURS.ink,
-  })
+  if (showDraftBadge) {
+    const draftText = 'DRAFT'
+    const draftWidth = fonts.bold.widthOfTextAtSize(draftText, 9)
+    page.drawRectangle({
+      x: PAGE_W - MARGIN - labelWidth - draftWidth - 14,
+      y: PAGE_H - HEADER_H + 5,
+      width: draftWidth + 10,
+      height: 16,
+      color: COLOURS.draft,
+    })
+    page.drawText(draftText, {
+      x: PAGE_W - MARGIN - labelWidth - draftWidth - 9,
+      y: PAGE_H - HEADER_H + 8,
+      size: 9,
+      font: fonts.bold,
+      color: rgb(1, 1, 1),
+    })
+  }
 }
 
-function drawComponentTable(args: {
-  page: ReturnType<PDFDocument['addPage']>
+function metaFieldsForRender(args: {
+  cmfCode: string
+  packetName: string
+  productLabel: string
+  productCode: string | null
+  ean: string | null
+  generatedAt: Date
+  drawn?: string | null
+}): MetaField[] {
+  return [
+    { label: 'CMF number', value: args.cmfCode },
+    { label: 'Collection', value: args.packetName },
+    { label: 'Product name', value: args.productLabel },
+    { label: 'Product code', value: args.productCode ?? '—' },
+    { label: 'EAN code', value: args.ean ?? '—' },
+    { label: 'Edit date', value: args.generatedAt.toISOString().slice(0, 10) },
+    { label: 'Drawn', value: args.drawn ?? '' },
+    { label: 'Checked', value: '' },
+    { label: 'Checked', value: '' },
+  ]
+}
+
+/* ── Per-component vertical spec list (Damien's "Material / Finish /
+ *    Colour / Artwork" stack per component) ────────────────────────────── */
+
+function drawComponentSpecList(args: {
+  page: PDFPage
   fonts: PdfFontPair
   components: ComponentSpec[]
   x: number
   y: number
   width: number
-}) {
-  const { page, fonts, components, x, y, width } = args
-  const headerSize = 9
-  const rowSize = 11
-  const rowHeight = 22
-
-  const headers = ['Component', 'Pantone / Hex', 'Material', 'Finish', 'Technique']
-  const colWidths = [width * 0.22, width * 0.22, width * 0.18, width * 0.18, width * 0.2]
-
-  let cursor = y
-  let cx = x
-  for (let i = 0; i < headers.length; i++) {
-    page.drawText(headers[i].toUpperCase(), {
-      x: cx,
-      y: cursor,
-      size: headerSize,
-      font: fonts.bold,
-      color: COLOURS.muted,
-    })
-    cx += colWidths[i]
-  }
-  cursor -= 8
-  page.drawRectangle({
-    x,
-    y: cursor,
-    width,
-    height: 1,
-    color: COLOURS.faint,
-  })
-  cursor -= rowHeight - 4
+}): number {
+  const { page, fonts, components, x, width } = args
+  let cursor = args.y
 
   for (const comp of components) {
-    cx = x
-    const colour = comp.colorHex || null
-    const swatch = colour ? hexToRgb01(colour) : null
+    if (cursor < FOOTER_H + 50) break
+
+    const swatch = hexToRgb01(comp.colorHex ?? null)
     if (swatch) {
       page.drawRectangle({
-        x: cx,
-        y: cursor - 4,
-        width: 12,
-        height: 12,
+        x,
+        y: cursor - 1,
+        width: 10,
+        height: 10,
         color: swatch,
         borderColor: COLOURS.swatchBorder,
         borderWidth: 0.5,
       })
     }
-    page.drawText(comp.label, {
-      x: cx + (swatch ? 18 : 0),
+    page.drawText(comp.label.toUpperCase(), {
+      x: x + (swatch ? 16 : 0),
       y: cursor,
-      size: rowSize,
-      font: fonts.bold,
-      color: COLOURS.ink,
-    })
-    cx += colWidths[0]
-
-    const pantoneText = comp.pantone || comp.colorHex || '—'
-    page.drawText(pantoneText.slice(0, 28), {
-      x: cx,
-      y: cursor,
-      size: rowSize,
-      font: fonts.mono,
-      color: COLOURS.ink,
-    })
-    cx += colWidths[1]
-
-    page.drawText((comp.material || '—').slice(0, 24), {
-      x: cx,
-      y: cursor,
-      size: rowSize,
-      font: fonts.regular,
-      color: COLOURS.ink,
-    })
-    cx += colWidths[2]
-
-    page.drawText((comp.finish || '—').slice(0, 24), {
-      x: cx,
-      y: cursor,
-      size: rowSize,
-      font: fonts.regular,
-      color: COLOURS.ink,
-    })
-    cx += colWidths[3]
-
-    page.drawText((comp.technique || '—').slice(0, 28), {
-      x: cx,
-      y: cursor,
-      size: rowSize,
-      font: fonts.regular,
-      color: COLOURS.muted,
-    })
-
-    cursor -= rowHeight
-  }
-}
-
-function drawPalette(args: {
-  page: ReturnType<PDFDocument['addPage']>
-  fonts: PdfFontPair
-  components: ComponentSpec[]
-  palette: PaletteSwatch[]
-  x: number
-  y: number
-  width: number
-}) {
-  const { page, fonts, components, palette, x, y, width } = args
-
-  page.drawText('Palette'.toUpperCase(), {
-    x,
-    y,
-    size: 9,
-    font: fonts.bold,
-    color: COLOURS.muted,
-  })
-
-  // Combine palette swatches with component-derived colours, dedup by hex.
-  const swatches: PaletteSwatch[] = []
-  const seen = new Set<string>()
-  for (const p of palette) {
-    const key = (p.colorHex || p.pantone || p.label || '').toLowerCase()
-    if (key && !seen.has(key)) {
-      seen.add(key)
-      swatches.push(p)
-    }
-  }
-  for (const c of components) {
-    const key = (c.colorHex || c.pantone || c.label || '').toLowerCase()
-    if (!key || seen.has(key)) continue
-    seen.add(key)
-    swatches.push({
-      label: c.label,
-      pantone: c.pantone ?? undefined,
-      colorHex: c.colorHex ?? undefined,
-    })
-  }
-
-  const swatchSize = 32
-  const gap = 16
-  const perRow = Math.max(1, Math.floor((width + gap) / (swatchSize * 4 + gap)))
-  let cx = x
-  let cy = y - swatchSize - 12
-  let count = 0
-  for (const swatch of swatches) {
-    const colour = swatch.colorHex ? hexToRgb01(swatch.colorHex) : null
-    page.drawRectangle({
-      x: cx,
-      y: cy,
-      width: swatchSize,
-      height: swatchSize,
-      color: colour ?? rgb(0.92, 0.92, 0.94),
-      borderColor: COLOURS.swatchBorder,
-      borderWidth: 0.6,
-    })
-    page.drawText(swatch.label.slice(0, 18), {
-      x: cx + swatchSize + 8,
-      y: cy + swatchSize - 12,
       size: 9,
       font: fonts.bold,
       color: COLOURS.ink,
+      maxWidth: width - (swatch ? 16 : 0),
     })
-    page.drawText((swatch.pantone || swatch.colorHex || '').slice(0, 22), {
-      x: cx + swatchSize + 8,
-      y: cy + swatchSize - 24,
+    cursor -= 14
+
+    const rows: Array<[string, string]> = [
+      ['Material', comp.material ?? '—'],
+      ['Finish', comp.finish ?? '—'],
+      ['Colour', comp.pantone ?? comp.colorHex ?? '—'],
+      ['Artwork', comp.technique ?? comp.notes ?? '—'],
+    ]
+    for (const [k, v] of rows) {
+      page.drawText(k, {
+        x: x + 10,
+        y: cursor,
+        size: 8,
+        font: fonts.regular,
+        color: COLOURS.muted,
+      })
+      drawWrappedText({
+        page,
+        text: v,
+        x: x + 70,
+        y: cursor,
+        size: 8,
+        font: fonts.regular,
+        color: COLOURS.ink,
+        maxWidth: width - 80,
+      })
+      cursor -= 11
+    }
+    cursor -= 6 // gap between components
+  }
+
+  return cursor
+}
+
+function drawFooter(args: {
+  page: PDFPage
+  fonts: PdfFontPair
+  pageIndex: number
+  totalPages: number
+  notes?: string | null
+}) {
+  const { page, fonts, pageIndex, totalPages, notes } = args
+  page.drawRectangle({
+    x: 0,
+    y: FOOTER_H - 1,
+    width: PAGE_W,
+    height: 1,
+    color: COLOURS.faint,
+  })
+
+  if (notes) {
+    drawWrappedText({
+      page,
+      text: notes,
+      x: MARGIN,
+      y: FOOTER_H - 14,
+      size: 7,
+      font: fonts.regular,
+      color: COLOURS.muted,
+      maxWidth: PAGE_W - MARGIN * 2 - 80,
+    })
+  }
+
+  const pageLabel = `-- ${pageIndex} of ${totalPages} --`
+  const w = fonts.mono.widthOfTextAtSize(pageLabel, 8)
+  page.drawText(pageLabel, {
+    x: PAGE_W - MARGIN - w,
+    y: FOOTER_H - 18,
+    size: 8,
+    font: fonts.mono,
+    color: COLOURS.muted,
+  })
+}
+
+/* ── Page 1 (CMF spec + product render) ─────────────────────────────────── */
+
+interface SkuPageArgs {
+  pdf: PDFDocument
+  fonts: PdfFontPair
+  render: RenderProjection
+  meta: MetaField[]
+  pageIndex: number
+  totalPages: number
+  packetNotes: string | null
+  isDraft: boolean
+}
+
+interface RenderProjection {
+  id: string
+  label: string
+  colorwayName: string | null
+  productSlug: string
+  productCode: string | null
+  ean: string | null
+  componentSpecs: unknown
+  paletteSwatches: unknown
+  renderUrl: string | null
+  enhancedPrompt: string | null
+  status: string
+}
+
+async function drawProductRenderPage(args: SkuPageArgs) {
+  const { pdf, fonts, render, meta, pageIndex, totalPages, packetNotes, isDraft } = args
+  const page = pdf.addPage([PAGE_W, PAGE_H])
+
+  drawSourceHeader({
+    page,
+    fonts,
+    fields: meta,
+    pageLabel: 'CMF Page 1',
+    showDraftBadge: isDraft,
+  })
+
+  // "Product render" section title
+  const sectionY = PAGE_H - HEADER_H - 20
+  page.drawText('Product render', {
+    x: MARGIN,
+    y: sectionY,
+    size: 11,
+    font: fonts.bold,
+    color: COLOURS.ink,
+  })
+
+  // Hero plate for the render image (left two-thirds, ~50% of page height
+  // so the spec list always has room below it).
+  const imageBoxX = MARGIN
+  const imageBoxW = PAGE_W - MARGIN * 2
+  const imageBoxH = (PAGE_H - HEADER_H - FOOTER_H) * 0.45
+  const imageBoxY = sectionY - 12 - imageBoxH
+
+  page.drawRectangle({
+    x: imageBoxX,
+    y: imageBoxY,
+    width: imageBoxW,
+    height: imageBoxH,
+    color: COLOURS.panelBg,
+    borderColor: COLOURS.faint,
+    borderWidth: 0.5,
+  })
+
+  const embedded = await embedRenderImage(pdf, render.renderUrl)
+  if (embedded) {
+    const aspect = embedded.width / embedded.height
+    let drawW = imageBoxW - 16
+    let drawH = drawW / aspect
+    if (drawH > imageBoxH - 16) {
+      drawH = imageBoxH - 16
+      drawW = drawH * aspect
+    }
+    page.drawImage(embedded, {
+      x: imageBoxX + (imageBoxW - drawW) / 2,
+      y: imageBoxY + (imageBoxH - drawH) / 2,
+      width: drawW,
+      height: drawH,
+    })
+  } else {
+    const placeholder =
+      render.status === 'ready' ? 'Render not available' : 'Render not generated yet'
+    const w = fonts.regular.widthOfTextAtSize(placeholder, 10)
+    page.drawText(placeholder, {
+      x: imageBoxX + (imageBoxW - w) / 2,
+      y: imageBoxY + imageBoxH / 2,
+      size: 10,
+      font: fonts.regular,
+      color: COLOURS.muted,
+    })
+  }
+
+  // Component spec list (vertical stack, one block per component) below the
+  // render plate. Damien's template keeps Material / Finish / Colour /
+  // Artwork in a labelled key/value column so the factory sheet stays
+  // readable when printed.
+  const components = (render.componentSpecs as ComponentSpec[] | undefined) ?? []
+  drawComponentSpecList({
+    page,
+    fonts,
+    components,
+    x: MARGIN,
+    y: imageBoxY - 18,
+    width: PAGE_W - MARGIN * 2,
+  })
+
+  drawFooter({ page, fonts, pageIndex, totalPages, notes: packetNotes })
+}
+
+/* ── Page 2 (Part break down grid) ──────────────────────────────────────── */
+
+async function drawPartBreakdownPage(args: SkuPageArgs) {
+  const { pdf, fonts, render, meta, pageIndex, totalPages, packetNotes, isDraft } = args
+  const page = pdf.addPage([PAGE_W, PAGE_H])
+
+  drawSourceHeader({
+    page,
+    fonts,
+    fields: meta,
+    pageLabel: 'Part Break Down Page 2',
+    showDraftBadge: isDraft,
+  })
+
+  const sectionY = PAGE_H - HEADER_H - 20
+  page.drawText('Part break down', {
+    x: MARGIN,
+    y: sectionY,
+    size: 11,
+    font: fonts.bold,
+    color: COLOURS.ink,
+  })
+
+  const components = (render.componentSpecs as ComponentSpec[] | undefined) ?? []
+  if (components.length === 0) {
+    page.drawText('No components recorded for this SKU.', {
+      x: MARGIN,
+      y: sectionY - 24,
+      size: 10,
+      font: fonts.regular,
+      color: COLOURS.muted,
+    })
+    drawFooter({ page, fonts, pageIndex, totalPages, notes: packetNotes })
+    return
+  }
+
+  // 2-column grid; each cell shows component name, swatch, Pantone, material
+  // and finish. Two columns keep cells big enough for printing without
+  // requiring a designer to squint.
+  const gridX = MARGIN
+  const gridY = sectionY - 18
+  const cols = 2
+  const gridW = PAGE_W - MARGIN * 2
+  const cellW = (gridW - 16 * (cols - 1)) / cols
+  const cellH = 130
+
+  for (let i = 0; i < components.length; i++) {
+    const comp = components[i]
+    const col = i % cols
+    const row = Math.floor(i / cols)
+    const x = gridX + col * (cellW + 16)
+    const y = gridY - row * (cellH + 16)
+    const cellBottom = y - cellH
+
+    if (cellBottom < FOOTER_H + 16) break
+
+    page.drawRectangle({
+      x,
+      y: cellBottom,
+      width: cellW,
+      height: cellH,
+      color: COLOURS.panelBg,
+      borderColor: COLOURS.faint,
+      borderWidth: 0.5,
+    })
+
+    // Component name banner
+    page.drawText(comp.label.toUpperCase(), {
+      x: x + 10,
+      y: y - 16,
+      size: 9,
+      font: fonts.bold,
+      color: COLOURS.primary,
+      maxWidth: cellW - 20,
+    })
+
+    // Swatch block on the right side
+    const swatch = hexToRgb01(comp.colorHex ?? null)
+    const swatchSize = 38
+    page.drawRectangle({
+      x: x + cellW - swatchSize - 10,
+      y: y - swatchSize - 14,
+      width: swatchSize,
+      height: swatchSize,
+      color: swatch ?? rgb(0.92, 0.92, 0.94),
+      borderColor: COLOURS.swatchBorder,
+      borderWidth: 0.5,
+    })
+
+    // Key/value lines on the left
+    let textY = y - 32
+    const rows: Array<[string, string]> = [
+      ['Pantone', comp.pantone ?? comp.colorHex ?? '—'],
+      ['Material', comp.material ?? '—'],
+      ['Finish', comp.finish ?? '—'],
+      ['Technique', comp.technique ?? '—'],
+    ]
+    const textW = cellW - swatchSize - 30
+    for (const [k, v] of rows) {
+      page.drawText(k.toUpperCase(), {
+        x: x + 10,
+        y: textY,
+        size: 6,
+        font: fonts.bold,
+        color: COLOURS.muted,
+      })
+      textY -= 9
+      drawWrappedText({
+        page,
+        text: v,
+        x: x + 10,
+        y: textY,
+        size: 8,
+        font: fonts.regular,
+        color: COLOURS.ink,
+        maxWidth: textW,
+      })
+      textY -= 16
+    }
+  }
+
+  drawFooter({ page, fonts, pageIndex, totalPages, notes: packetNotes })
+}
+
+/* ── Optional pack-overview page (multi-SKU only) ───────────────────────── */
+
+async function drawPackOverviewPage(args: {
+  pdf: PDFDocument
+  fonts: PdfFontPair
+  renders: RenderProjection[]
+  baseMeta: MetaField[]
+  pageIndex: number
+  totalPages: number
+  packetName: string
+  packetNotes: string | null
+  cmfCode: string
+  generatedAt: Date
+}) {
+  const {
+    pdf,
+    fonts,
+    renders,
+    baseMeta,
+    pageIndex,
+    totalPages,
+    packetName,
+    packetNotes,
+    cmfCode,
+    generatedAt,
+  } = args
+  const page = pdf.addPage([PAGE_W, PAGE_H])
+
+  drawSourceHeader({
+    page,
+    fonts,
+    fields: [
+      { label: 'CMF number', value: cmfCode },
+      { label: 'Collection', value: packetName },
+      { label: 'Pack size', value: `${renders.length} SKUs` },
+      ...baseMeta.slice(3, 9),
+    ],
+    pageLabel: 'Pack overview',
+  })
+
+  page.drawText('Pack breakdown', {
+    x: MARGIN,
+    y: PAGE_H - HEADER_H - 20,
+    size: 11,
+    font: fonts.bold,
+    color: COLOURS.ink,
+  })
+
+  // SKU cards: colourway title, product slug, mini swatch row.
+  const colCount = Math.min(renders.length, 2)
+  const gridW = PAGE_W - MARGIN * 2
+  const cellW = (gridW - 16 * (colCount - 1)) / colCount
+  const cellH = 110
+  let cellX = MARGIN
+  let cellY = PAGE_H - HEADER_H - 40
+
+  renders.forEach((render, idx) => {
+    const components = (render.componentSpecs as ComponentSpec[] | undefined) ?? []
+    page.drawRectangle({
+      x: cellX,
+      y: cellY - cellH,
+      width: cellW,
+      height: cellH,
+      color: COLOURS.panelBg,
+      borderColor: COLOURS.faint,
+      borderWidth: 0.5,
+    })
+
+    page.drawText((render.colorwayName ?? render.label).toUpperCase(), {
+      x: cellX + 10,
+      y: cellY - 16,
+      size: 11,
+      font: fonts.bold,
+      color: COLOURS.primary,
+      maxWidth: cellW - 20,
+    })
+    page.drawText(render.productSlug, {
+      x: cellX + 10,
+      y: cellY - 30,
       size: 8,
       font: fonts.mono,
       color: COLOURS.muted,
     })
-
-    count += 1
-    if (count % perRow === 0) {
-      cx = x
-      cy -= swatchSize + 14
-    } else {
-      cx += swatchSize * 4 + gap
+    if (render.productCode) {
+      page.drawText(render.productCode, {
+        x: cellX + 10,
+        y: cellY - 42,
+        size: 7,
+        font: fonts.mono,
+        color: COLOURS.muted,
+      })
     }
-  }
+
+    // Mini swatch row
+    let swatchX = cellX + 10
+    const swatchY = cellY - 70
+    for (const comp of components.slice(0, 6)) {
+      const colour = hexToRgb01(comp.colorHex ?? null)
+      page.drawRectangle({
+        x: swatchX,
+        y: swatchY,
+        width: 18,
+        height: 18,
+        color: colour ?? rgb(0.92, 0.92, 0.94),
+        borderColor: COLOURS.swatchBorder,
+        borderWidth: 0.5,
+      })
+      swatchX += 24
+    }
+
+    // Advance grid cursor
+    if ((idx + 1) % colCount === 0) {
+      cellX = MARGIN
+      cellY -= cellH + 16
+    } else {
+      cellX += cellW + 16
+    }
+  })
+
+  drawFooter({ page, fonts, pageIndex, totalPages, notes: packetNotes })
 }
+
+/* ── Public ─────────────────────────────────────────────────────────────── */
 
 interface BuildPdfArgs {
   packetName: string
   cmfCode: string | null
   notes: string | null
   generatedAt?: Date
+  /** Optional designer name to fill the "Drawn:" cell in the meta header. */
+  drawnBy?: string | null
+  /** When true, every page receives a DRAFT badge so the export is visibly
+   * marked as a non-approved deliverable. */
+  isDraft?: boolean
   renders: Array<Pick<CmfRender,
     'id' |
     'label' |
@@ -408,8 +780,9 @@ interface BuildPdfArgs {
 
 export async function buildCmfPacketPdf(args: BuildPdfArgs): Promise<Uint8Array> {
   const generatedAt = args.generatedAt ?? new Date()
+  const cmfCode = args.cmfCode ?? 'CMF-DRAFT'
   const pdf = await PDFDocument.create()
-  pdf.setTitle(`${args.cmfCode ?? 'CMF'} · ${args.packetName}`)
+  pdf.setTitle(`${cmfCode} · ${args.packetName}`)
   pdf.setProducer('Loop Vesper · CMF Studio')
   pdf.setCreator('Loop Vesper · CMF Studio')
 
@@ -418,217 +791,104 @@ export async function buildCmfPacketPdf(args: BuildPdfArgs): Promise<Uint8Array>
   const courier = await pdf.embedFont(StandardFonts.Courier)
   const fonts: PdfFontPair = { regular: helvetica, bold: helveticaBold, mono: courier }
 
-  for (const render of args.renders) {
+  const includesOverview = args.renders.length > 1
+  // 2 pages per SKU + optional overview page when multi-SKU.
+  const totalPages = args.renders.length * 2 + (includesOverview ? 1 : 0)
+
+  let pageIndex = 1
+  const baseMetaFor = (render: BuildPdfArgs['renders'][number]): MetaField[] => {
     const product = getCmfProduct(render.productSlug)
-    const components = (render.componentSpecs as unknown as ComponentSpec[]) ?? []
-    const palette = (render.paletteSwatches as unknown as PaletteSwatch[]) ?? []
-
-    const page = pdf.addPage([PAGE_W, PAGE_H])
-    drawBanner({
-      page,
-      fonts,
-      cmfCode: args.cmfCode ?? render.label.toUpperCase(),
-      productName: `${product?.name ?? render.productSlug}${render.productCode ? ` · ${render.productCode}` : ''}`,
-      colorwayName: render.colorwayName ?? render.label,
+    const productLabel = render.colorwayName
+      ? `${product?.name ?? render.productSlug} · ${render.colorwayName}`
+      : product?.name ?? render.label
+    return metaFieldsForRender({
+      cmfCode,
+      packetName: args.packetName,
+      productLabel,
+      productCode: render.productCode,
+      ean: render.ean,
       generatedAt,
+      drawn: args.drawnBy ?? null,
     })
-
-    // Render image area on the left half
-    const imageBoxX = MARGIN
-    const imageBoxY = MARGIN + FOOTER_H + 16
-    const imageBoxW = (PAGE_W / 2) - MARGIN - 16
-    const imageBoxH = PAGE_H - BANNER_H - imageBoxY - 16
-
-    page.drawRectangle({
-      x: imageBoxX,
-      y: imageBoxY,
-      width: imageBoxW,
-      height: imageBoxH,
-      color: rgb(0.97, 0.97, 0.98),
-      borderColor: COLOURS.faint,
-      borderWidth: 1,
-    })
-
-    const embedded = await embedRenderImage(pdf, render.renderUrl)
-    if (embedded) {
-      const aspect = embedded.width / embedded.height
-      let drawW = imageBoxW - 24
-      let drawH = drawW / aspect
-      if (drawH > imageBoxH - 24) {
-        drawH = imageBoxH - 24
-        drawW = drawH * aspect
-      }
-      page.drawImage(embedded, {
-        x: imageBoxX + (imageBoxW - drawW) / 2,
-        y: imageBoxY + (imageBoxH - drawH) / 2,
-        width: drawW,
-        height: drawH,
-      })
-    } else {
-      const placeholder = render.status === 'ready'
-        ? 'Render not available'
-        : 'Render not generated yet'
-      const w = fonts.regular.widthOfTextAtSize(placeholder, 11)
-      page.drawText(placeholder, {
-        x: imageBoxX + (imageBoxW - w) / 2,
-        y: imageBoxY + imageBoxH / 2,
-        size: 11,
-        font: fonts.regular,
-        color: COLOURS.muted,
-      })
-    }
-
-    // Right column: spec table
-    const tableX = PAGE_W / 2 + 16
-    const tableY = PAGE_H - BANNER_H - 48
-    const tableW = PAGE_W - tableX - MARGIN
-
-    page.drawText('CMF Spec'.toUpperCase(), {
-      x: tableX,
-      y: tableY + 22,
-      size: 11,
-      font: fonts.bold,
-      color: COLOURS.primary,
-    })
-    drawComponentTable({
-      page,
-      fonts,
-      components,
-      x: tableX,
-      y: tableY,
-      width: tableW,
-    })
-
-    // Footer: palette on the left, EAN/notes on the right
-    drawPalette({
-      page,
-      fonts,
-      components,
-      palette,
-      x: MARGIN,
-      y: MARGIN + FOOTER_H - 10,
-      width: PAGE_W / 2 - MARGIN,
-    })
-
-    const metaX = PAGE_W / 2 + 16
-    const metaY = MARGIN + FOOTER_H - 10
-    page.drawText('Identity'.toUpperCase(), {
-      x: metaX,
-      y: metaY,
-      size: 9,
-      font: fonts.bold,
-      color: COLOURS.muted,
-    })
-    let metaCursor = metaY - 16
-    if (render.productCode) {
-      page.drawText(`Product code  ${render.productCode}`, {
-        x: metaX,
-        y: metaCursor,
-        size: 10,
-        font: fonts.mono,
-        color: COLOURS.ink,
-      })
-      metaCursor -= 14
-    }
-    if (render.ean) {
-      page.drawText(`EAN  ${render.ean}`, {
-        x: metaX,
-        y: metaCursor,
-        size: 10,
-        font: fonts.mono,
-        color: COLOURS.ink,
-      })
-      metaCursor -= 14
-    }
-    if (args.notes) {
-      drawWrappedText({
-        page,
-        text: args.notes,
-        x: metaX,
-        y: metaCursor,
-        size: 9,
-        font: fonts.regular,
-        color: COLOURS.muted,
-        maxWidth: PAGE_W - metaX - MARGIN,
-      })
-    }
   }
 
-  // Shared breakdown page for multi-SKU packets.
-  if (args.renders.length > 1) {
-    const page = pdf.addPage([PAGE_W, PAGE_H])
-    drawBanner({
-      page,
-      fonts,
-      cmfCode: args.cmfCode ?? 'CMF Pack',
-      productName: args.packetName,
-      colorwayName: 'Pack breakdown',
-      generatedAt,
-    })
-
-    const colCount = Math.min(args.renders.length, 4)
-    const cellW = (PAGE_W - MARGIN * 2 - (colCount - 1) * 24) / colCount
-    let cellX = MARGIN
-    let cellY = PAGE_H - BANNER_H - 48
-    for (const render of args.renders) {
-      const components = (render.componentSpecs as unknown as ComponentSpec[]) ?? []
-      // Title block per SKU
-      page.drawText((render.colorwayName ?? render.label).toUpperCase(), {
-        x: cellX,
-        y: cellY,
-        size: 12,
-        font: fonts.bold,
-        color: COLOURS.primary,
-      })
-      page.drawText(render.productSlug, {
-        x: cellX,
-        y: cellY - 16,
-        size: 9,
-        font: fonts.mono,
-        color: COLOURS.muted,
-      })
-      // Mini swatch row
-      let swatchX = cellX
-      const swatchY = cellY - 38
-      for (const comp of components.slice(0, 6)) {
-        const colour = hexToRgb01(comp.colorHex)
-        page.drawRectangle({
-          x: swatchX,
-          y: swatchY - 18,
-          width: 20,
-          height: 20,
-          color: colour ?? rgb(0.9, 0.9, 0.92),
-          borderColor: COLOURS.swatchBorder,
-          borderWidth: 0.6,
-        })
-        page.drawText(comp.label.slice(0, 14), {
-          x: swatchX,
-          y: swatchY - 32,
-          size: 7,
-          font: fonts.regular,
-          color: COLOURS.muted,
-        })
-        swatchX += 26
-      }
-
-      cellX += cellW + 24
-      if (cellX + cellW > PAGE_W - MARGIN) {
-        cellX = MARGIN
-        cellY -= 140
-      }
+  for (const render of args.renders) {
+    const meta = baseMetaFor(render)
+    const projection: RenderProjection = {
+      id: render.id,
+      label: render.label,
+      colorwayName: render.colorwayName,
+      productSlug: render.productSlug,
+      productCode: render.productCode,
+      ean: render.ean,
+      componentSpecs: render.componentSpecs,
+      paletteSwatches: render.paletteSwatches,
+      renderUrl: render.renderUrl,
+      enhancedPrompt: render.enhancedPrompt,
+      status: render.status,
     }
 
-    drawWrappedText({
-      page,
-      text: args.notes ?? '',
-      x: MARGIN,
-      y: MARGIN + 36,
-      size: 9,
-      font: fonts.regular,
-      color: COLOURS.muted,
-      maxWidth: PAGE_W - MARGIN * 2,
+    await drawProductRenderPage({
+      pdf,
+      fonts,
+      render: projection,
+      meta,
+      pageIndex,
+      totalPages,
+      packetNotes: args.notes,
+      isDraft: !!args.isDraft,
+    })
+    pageIndex += 1
+
+    await drawPartBreakdownPage({
+      pdf,
+      fonts,
+      render: projection,
+      meta,
+      pageIndex,
+      totalPages,
+      packetNotes: args.notes,
+      isDraft: !!args.isDraft,
+    })
+    pageIndex += 1
+  }
+
+  if (includesOverview) {
+    await drawPackOverviewPage({
+      pdf,
+      fonts,
+      renders: args.renders.map((render) => ({
+        id: render.id,
+        label: render.label,
+        colorwayName: render.colorwayName,
+        productSlug: render.productSlug,
+        productCode: render.productCode,
+        ean: render.ean,
+        componentSpecs: render.componentSpecs,
+        paletteSwatches: render.paletteSwatches,
+        renderUrl: render.renderUrl,
+        enhancedPrompt: render.enhancedPrompt,
+        status: render.status,
+      })),
+      baseMeta: baseMetaFor(args.renders[0]),
+      pageIndex,
+      totalPages,
+      packetName: args.packetName,
+      packetNotes: args.notes,
+      cmfCode,
+      generatedAt,
     })
   }
 
   return pdf.save()
 }
+
+/* ── Page geometry exports (consumers that need to mirror layout) ───────── */
+
+export const CMF_PDF_GEOMETRY = {
+  PAGE_W,
+  PAGE_H,
+  HEADER_H,
+  FOOTER_H,
+  MARGIN,
+} as const

--- a/src/lib/cmf/prompt.ts
+++ b/src/lib/cmf/prompt.ts
@@ -27,8 +27,85 @@
  * Vesper `enhancePrompt` service for Nano Banana–optimised polishing.
  */
 
-import type { CmfSkuRow, ComponentSpec } from './schema'
+import type { CmfSkuRow, ComponentSpec, PaletteSwatch } from './schema'
 import { getCmfProduct } from './products'
+
+/* ── Clown reference metadata ──────────────────────────────────────────── */
+
+/**
+ * The "clown" reference image is a multi-coloured render of the product
+ * where each recolourable surface is painted a distinct, easy-to-identify
+ * colour. When the resolved clown asset carries per-region colour metadata,
+ * we can tell the model which clown colour maps to which CMF component
+ * instead of relying on label-only addressing.
+ *
+ * Example: "the red surface on the reference (POM ring): recolour to
+ * Pantone 7720C …" gives Nano Banana an unambiguous region anchor and
+ * dramatically improves which surface actually gets the new material.
+ */
+export interface ClownComponentMeta {
+  region: string
+  label: string
+  colorHex?: string | null
+}
+
+/**
+ * Map an unbounded hex value to a short, model-friendly colour word. Hex
+ * itself is ambiguous to image models ("#ff3344 region" is hard to spot);
+ * named colours line up with how a designer points at the clown verbally.
+ */
+function describeClownHex(hex: string): string {
+  const normalised = hex.startsWith('#') ? hex.slice(1) : hex
+  if (normalised.length !== 6) return hex
+  const r = parseInt(normalised.slice(0, 2), 16)
+  const g = parseInt(normalised.slice(2, 4), 16)
+  const b = parseInt(normalised.slice(4, 6), 16)
+  // HSL conversion for an easy hue/saturation/lightness bucketing.
+  const rN = r / 255
+  const gN = g / 255
+  const bN = b / 255
+  const max = Math.max(rN, gN, bN)
+  const min = Math.min(rN, gN, bN)
+  const l = (max + min) / 2
+  const d = max - min
+  let h = 0
+  let s = 0
+  if (d !== 0) {
+    s = d / (1 - Math.abs(2 * l - 1))
+    switch (max) {
+      case rN:
+        h = ((gN - bN) / d) % 6
+        break
+      case gN:
+        h = (bN - rN) / d + 2
+        break
+      default:
+        h = (rN - gN) / d + 4
+    }
+    h = Math.round(h * 60)
+    if (h < 0) h += 360
+  }
+
+  // Very dark / very light → grayscale buckets, even when saturated.
+  if (l < 0.1) return 'near-black'
+  if (l > 0.92 && s < 0.2) return 'white'
+  if (s < 0.12) return l < 0.4 ? 'dark grey' : l > 0.7 ? 'light grey' : 'grey'
+
+  // Hue buckets tuned for the clown palettes designers tend to author.
+  if (h < 15 || h >= 345) return 'red'
+  if (h < 35) return 'orange'
+  if (h < 55) return 'yellow-orange'
+  if (h < 70) return 'yellow'
+  if (h < 95) return 'lime green'
+  if (h < 150) return 'green'
+  if (h < 175) return 'teal'
+  if (h < 200) return 'cyan'
+  if (h < 235) return 'blue'
+  if (h < 265) return 'indigo'
+  if (h < 290) return 'purple'
+  if (h < 320) return 'magenta'
+  return 'pink'
+}
 
 /* ── Prompt variants ───────────────────────────────────────────────────── */
 
@@ -110,38 +187,60 @@ function describeMaterial(component: ComponentSpec): string {
   const wantsGloss = /(gloss|highgloss|mirror|polished)/.test(finishLower)
   const wantsNcvm = /(ncvm)/.test(finishLower)
   const wantsBrushed = /(brushed|satin|anodised|anodized)/.test(finishLower)
-  const wantsMatte = /(matte|matt|vdi\s*2[0-9]|vdi\s*1[0-9])/.test(finishLower)
+  // VDI 21 / VDI 22 are explicit matte texture spec; treat them as the
+  // "deep matte" cue the factory sheet expects.
+  const wantsVdiMatte = /(vdi\s*2[0-9]|vdi\s*1[0-9])/.test(finishLower)
+  const wantsMatte = /(matte|matt)/.test(finishLower) || wantsVdiMatte
   const wantsTranslucent = /(translucent|milky|see.?through|shore\s*30)/.test(
     m + ' ' + finishLower
   )
 
-  // POM
+  // POM — matte spec from Damien's Switch 2 pack. Carry the verbatim "Matte"
+  // wording the workbook uses so the model never confuses POM with a glossy
+  // injection-moulded plastic.
   if (m.includes('pom')) {
-    return `${raw} (subtle matte finish, fine micro-texture, no specular hotspots)`
+    if (wantsGloss) {
+      return `${raw} (rare gloss POM, sharp specular highlights, smooth micro-texture)`
+    }
+    return `${raw} (deeply matte engineering plastic, fine micro-texture, completely diffuse with no specular hotspots, body colour visible through pigment not coating)`
   }
 
   // Polycarbonate / ABS family
   if (m.includes('pc/abs') || m.includes('pc abs') || m.includes('polycarbonate')) {
     if (wantsGloss) {
-      return `${raw} (high-gloss mirror polish, sharp specular highlights, deep reflections)`
+      return `${raw} (high-gloss mirror polish, sharp specular highlights, deep reflections, smooth glassy injection-moulded surface)`
     }
     if (wantsNcvm) {
-      return `${raw} (NCVM-coated, satin metal-like finish, brushed anisotropic highlights, fine satin grain reminiscent of anodised aluminium)`
+      return `${raw} (NCVM-coated, satin metal-like finish, brushed anisotropic highlights, fine satin grain reminiscent of anodised aluminium, subtle metallic sheen layered on top of the plastic)`
+    }
+    if (wantsVdiMatte) {
+      return `${raw} (${component.finish} texture: deep matte injection-mould grain, fine even sand-like micro-texture, fully diffuse, no specular hotspots)`
     }
     return `${raw} (satin micro-texture, soft diffuse sheen, low specular response)`
   }
   if (m.includes('abs')) {
     if (wantsNcvm) {
-      return `${raw} (NCVM-coated, satin metal-like finish, brushed anisotropic highlights, fine satin grain reminiscent of anodised aluminium)`
+      return `${raw} (NCVM-coated, satin metal-like finish, brushed anisotropic highlights, fine satin grain reminiscent of anodised aluminium, subtle metallic sheen layered on top of the plastic)`
     }
     if (wantsGloss) {
-      return `${raw} (high-gloss surface, sharp specular highlights, deep reflections)`
+      return `${raw} (high-gloss injection-moulded plastic, sharp specular highlights, deep reflections, smooth glassy surface — clearly a polished plastic, not a metallic coating)`
+    }
+    if (wantsVdiMatte) {
+      return `${raw} (${component.finish} texture: deep matte injection-mould grain, fine even sand-like micro-texture, fully diffuse, no specular hotspots)`
     }
     return `${raw} (satin micro-texture, soft diffuse sheen, low specular response)`
   }
 
   // Silicone
   if (m.includes('silicon')) {
+    // "Milky see through 30%" reads as: clearly translucent, but only
+    // 30% light passes — i.e. frosted, not glassy. Spell that out so the
+    // model doesn't default to either fully opaque or fully transparent.
+    const seeThroughMatch = /see.?through\s*(\d{1,3})/.exec(finishLower)
+    if (seeThroughMatch) {
+      const pct = Math.min(95, Math.max(5, Number(seeThroughMatch[1] ?? '30')))
+      return `${raw} (translucent milky silicone, roughly ${pct}% light transmission so colour is clearly tinted but not glassy, gentle subsurface light scattering, frosted appearance, smooth rubbery micro-surface, light visibly passes through the thinner edges, no hard specular reflections)`
+    }
     if (wantsTranslucent || m.includes('shore 30')) {
       return `${raw} (translucent milky silicone with gentle subsurface light scattering, frosted appearance, smooth rubbery micro-surface, light visibly passes through the thinner edges, no hard reflections)`
     }
@@ -191,6 +290,8 @@ function describeMaterial(component: ComponentSpec): string {
   }
 
   // Generic fallback: workbook material wins, hint only if finish gives one.
+  if (wantsBrushed) return `${raw} (brushed/satin micro-texture, soft anisotropic sheen, no harsh highlights)`
+  if (wantsNcvm) return `${raw} (NCVM-coated, satin metal-like finish, brushed anisotropic highlights)`
   if (wantsMatte) return `${raw} (matte, diffuse, no specular hotspots)`
   if (wantsGloss) return `${raw} (high-gloss, sharp specular highlights)`
   return raw
@@ -208,10 +309,24 @@ function describeFinish(component: ComponentSpec): string {
 
 /* ── Per-component recolour line ───────────────────────────────────────── */
 
-function describeComponent(component: ComponentSpec): string {
+function describeComponent(
+  component: ComponentSpec,
+  clownByRegion: Map<string, ClownComponentMeta> | null
+): string {
   const colour = component.pantone
     ? `${component.pantone}${component.colorHex ? ` (≈ ${component.colorHex})` : ''}`
     : component.colorHex ?? null
+
+  // Anchor the line on the clown reference colour when we have one. This is
+  // the single biggest reason the model misses a region: the label "Cosmetic
+  // cap" is ambiguous in the reference, but "the orange surface (Cosmetic
+  // cap)" is not.
+  const clownMatch = clownByRegion?.get(component.region) ?? null
+  const clownColourWord =
+    clownMatch?.colorHex ? describeClownHex(clownMatch.colorHex) : null
+  const lineHead = clownColourWord
+    ? `${component.label} (the ${clownColourWord} surface on the reference)`
+    : component.label
 
   const parts: string[] = []
   if (colour) parts.push(`recolour to ${colour}`)
@@ -221,9 +336,19 @@ function describeComponent(component: ComponentSpec): string {
   if (finish) parts.push(finish)
   if (component.technique) parts.push(`technique: ${component.technique}`)
   if (parts.length === 0) {
-    return `${component.label}: keep as in the reference`
+    return `${lineHead}: keep as in the reference`
   }
-  return `${component.label}: ${parts.join(', ')}`
+  return `${lineHead}: ${parts.join(', ')}`
+}
+
+/* ── Palette context ───────────────────────────────────────────────────── */
+
+function describePaletteSwatch(swatch: PaletteSwatch): string | null {
+  const colour = swatch.pantone
+    ? `${swatch.pantone}${swatch.colorHex ? ` (≈ ${swatch.colorHex})` : ''}`
+    : swatch.colorHex ?? null
+  if (!colour) return null
+  return `${swatch.label} → ${colour}`
 }
 
 /* ── Public ─────────────────────────────────────────────────────────────── */
@@ -236,6 +361,13 @@ export interface BuildCmfPromptOptions {
    * still produces the canonical prompt.
    */
   variantIndex?: number
+  /**
+   * Optional clown reference metadata. When provided, prompt lines use
+   * "the {colour} surface on the reference (Label)" addressing instead of
+   * label-only, which dramatically improves which surface the model
+   * recolours. Falls back silently when no metadata is available.
+   */
+  clownComponents?: ClownComponentMeta[] | null
 }
 
 export interface BuildCmfPromptResult {
@@ -259,7 +391,17 @@ export function buildCmfPrompt(
     throw new Error(`Unknown CMF product slug: ${row.productSlug}`)
   }
 
-  const componentLines = row.components.map(describeComponent)
+  // Build a region → clown metadata lookup once so per-component rendering
+  // stays O(1). Skip entries without a hex (they add noise without info).
+  const clownByRegion = (() => {
+    const entries = (opts?.clownComponents ?? []).filter((c) => c.colorHex)
+    if (entries.length === 0) return null
+    return new Map(entries.map((c) => [c.region, c]))
+  })()
+
+  const componentLines = row.components.map((c) =>
+    describeComponent(c, clownByRegion)
+  )
 
   const protectedSurfaces = product.components
     .filter((c) => !row.components.find((rc) => rc.region === c.region))
@@ -273,10 +415,32 @@ export function buildCmfPrompt(
     `Using the provided 3D clown CMF render of ${productPhrase}, convert it into a photorealistic studio product shot in the "${colourwayLabel}" colourway.`,
     '',
     `Preserve the geometry, design, angle, framing, composition, and the relative positions of every unit exactly as in the source image. Do not alter the pose, perspective, scale, silhouette, parting lines, or any structural detail. Keep any text, markings, or labels (e.g. "L"/"R", logos, etched artwork) intact in the same location and orientation. Keep the source background unchanged.`,
-    '',
-    `Replace only the materials, colors, and lighting as follows:`,
-    ...componentLines.map((l) => `- ${l}`),
   ]
+
+  // Insert the clown reference legend right after the preserve clause so the
+  // model knows which surface maps to which label before it reads the
+  // recolour instructions. We only emit the legend for components the SKU
+  // is actually touching — listing untouched regions here just dilutes
+  // attention.
+  if (clownByRegion) {
+    const legendEntries: string[] = []
+    for (const component of row.components) {
+      const meta = clownByRegion.get(component.region)
+      if (meta?.colorHex) {
+        legendEntries.push(`${describeClownHex(meta.colorHex)} → ${component.label}`)
+      }
+    }
+    if (legendEntries.length > 0) {
+      lines.push('')
+      lines.push(
+        `Clown reference legend (which solid colour on the reference maps to which surface): ${legendEntries.join('; ')}.`
+      )
+    }
+  }
+
+  lines.push('')
+  lines.push(`Replace only the materials, colors, and lighting as follows:`)
+  lines.push(...componentLines.map((l) => `- ${l}`))
 
   if (protectedSurfaces.length > 0) {
     lines.push('')
@@ -285,12 +449,26 @@ export function buildCmfPrompt(
     )
   }
 
+  // Palette context: the workbook often carries an overall CMF palette
+  // beyond the per-component swatches (collection accents, packaging cues,
+  // etc.). Surface it so the model keeps cross-part colour harmony rather
+  // than treating every component as a free variable.
+  const paletteLines = (row.palette ?? [])
+    .map(describePaletteSwatch)
+    .filter((s): s is string => Boolean(s))
+  if (paletteLines.length > 0) {
+    lines.push('')
+    lines.push(
+      `Overall CMF palette context (for colour harmony, not extra surfaces to recolour): ${paletteLines.join('; ')}.`
+    )
+  }
+
   lines.push('')
   lines.push(variant.lightingClause)
 
   lines.push('')
   lines.push(
-    `Photorealistic 4K product render quality with believable micro-surface detail. Output should look like a real photographed sample, not a CGI render.`
+    `Photorealistic 4K product render quality with believable micro-surface detail. Material fidelity is critical — finish (matte vs satin vs gloss, NCVM, VDI texture, milky translucent silicone, brushed metal) must read correctly even when the colour is matched. Output should look like a real photographed sample, not a CGI render.`
   )
 
   if (row.notes) {

--- a/src/lib/cmf/render.ts
+++ b/src/lib/cmf/render.ts
@@ -70,7 +70,34 @@ interface ResolvedReferences {
     source: 'explicit' | 'exact-variant' | 'product-fallback'
     /** When `product-fallback`, how many variants the resolver was choosing among. */
     poolSize: number
+    /** Per-region colour metadata (when the clown was uploaded with one).
+     * Used by `buildCmfPrompt` to address surfaces by their clown colour. */
+    components: Array<{ region: string; label: string; colorHex?: string | null }>
   } | null
+}
+
+/** Best-effort parser for the `CmfClownAsset.components` JSON column. */
+function readClownComponents(
+  components: unknown
+): Array<{ region: string; label: string; colorHex?: string | null }> {
+  if (!Array.isArray(components)) return []
+  const out: Array<{ region: string; label: string; colorHex?: string | null }> = []
+  for (const entry of components) {
+    if (!entry || typeof entry !== 'object') continue
+    const region = (entry as { region?: unknown }).region
+    const label = (entry as { label?: unknown }).label
+    const colorHex =
+      (entry as { color_hex?: unknown }).color_hex ??
+      (entry as { colorHex?: unknown }).colorHex
+    if (typeof region !== 'string' || region.length === 0) continue
+    if (typeof label !== 'string' || label.length === 0) continue
+    out.push({
+      region,
+      label,
+      colorHex: typeof colorHex === 'string' ? colorHex : null,
+    })
+  }
+  return out
 }
 
 async function resolveRowReferences(args: {
@@ -104,6 +131,7 @@ async function resolveRowReferences(args: {
         label: asset.label,
         source: 'explicit',
         poolSize: 1,
+        components: readClownComponents(asset.components),
       },
     }
   }
@@ -129,6 +157,7 @@ async function resolveRowReferences(args: {
         label: exact.label,
         source: 'exact-variant',
         poolSize: 1,
+        components: readClownComponents(exact.components),
       },
     }
   }
@@ -155,6 +184,7 @@ async function resolveRowReferences(args: {
         label: picked.label,
         source: 'product-fallback',
         poolSize: pool.length,
+        components: readClownComponents(picked.components),
       },
     }
   }
@@ -163,6 +193,58 @@ async function resolveRowReferences(args: {
     'reference',
     'No clown reference image is available. Upload a clown PNG for this product before rendering.'
   )
+}
+
+/**
+ * Lightweight peek at the clown asset that *would* be picked for this SKU,
+ * returning only the per-region colour metadata. Used to feed the prompt
+ * builder so per-component recolour lines anchor on the actual clown colour
+ * ("the orange surface on the reference (Cosmetic cap): …") instead of
+ * labels only.
+ *
+ * Mirrors the resolution tiers used by `resolveRowReferences` but never
+ * downloads the image — that work still happens inside the render try
+ * block so storage errors are recorded against the attempt row.
+ */
+async function peekClownComponents(args: {
+  productSlug: string
+  variantSlug: string
+  clownAssetId: string | null
+  attemptNumber: number
+}): Promise<Array<{ region: string; label: string; colorHex?: string | null }>> {
+  try {
+    if (args.clownAssetId) {
+      const asset = await prisma.cmfClownAsset.findUnique({
+        where: { id: args.clownAssetId },
+        select: { components: true },
+      })
+      return readClownComponents(asset?.components)
+    }
+
+    const exact = await prisma.cmfClownAsset.findUnique({
+      where: {
+        productSlug_variantSlug: {
+          productSlug: args.productSlug,
+          variantSlug: args.variantSlug,
+        },
+      },
+      select: { components: true },
+    })
+    if (exact) return readClownComponents(exact.components)
+
+    const pool = await prisma.cmfClownAsset.findMany({
+      where: { productSlug: args.productSlug },
+      orderBy: [{ variantSlug: 'asc' }, { id: 'asc' }],
+      select: { components: true },
+    })
+    if (pool.length === 0) return []
+    const idx = ((args.attemptNumber - 1) % pool.length + pool.length) % pool.length
+    return readClownComponents(pool[idx].components)
+  } catch (err) {
+    // Best-effort: a missing metadata row should never block the render.
+    console.warn('[cmf/render] clown metadata peek failed; falling back to label-only prompt', err)
+    return []
+  }
 }
 
 function ensureSupportedModel(modelId: string): string {
@@ -224,8 +306,20 @@ export async function runCmfRender({ renderId, triggeredByUserId }: RenderArgs) 
   // burst produces a real fan of options. Variant 0 (Studio Classic) is
   // Damien's gold-standard; subsequent attempts cycle through Warm,
   // Clinical, Dramatic, then loop back.
+  //
+  // We also peek at which clown the reference resolver *would* pick so the
+  // prompt can address components by their clown colour ("the blue surface
+  // on the reference (Cosmetic cap): recolour to …"). Falls back silently
+  // when the resolved clown has no per-region colour metadata.
+  const clownComponents = await peekClownComponents({
+    productSlug: render.productSlug,
+    variantSlug: render.variantSlug,
+    clownAssetId: render.clownAssetId,
+    attemptNumber,
+  })
   const { basePrompt, variant } = buildCmfPrompt(row, {
     variantIndex: attemptNumber - 1,
+    clownComponents,
   })
 
   const attempt = await prisma.cmfRenderAttempt.create({

--- a/src/lib/skills/loop-cmf-generation/references/document-template.md
+++ b/src/lib/skills/loop-cmf-generation/references/document-template.md
@@ -1,77 +1,65 @@
 # Document Template
 
-Loop CMF documents have a recognisable shape: a banner, a hero render, a component spec table, a palette block, and identity metadata. Operations matches on these visible regions, so the template is LOCK and never changes per-product. SKU labels, ordering, and notes are editable in the HTML preview before export.
+Loop CMF documents have a recognisable shape: a top-of-page meta header (CMF number / Collection / Product name / Product code / EAN / Edit date / Drawn / Checked / Checked), a hero render with a vertical component spec list (Page 1), and a part breakdown grid (Page 2). The template mirrors Damien's source CMF deck so an exported PDF can drop straight into Loop's existing approval workflow without re-authoring.
 
 ## Contents
 
 - Page geometry
-- Banner
-- Hero region
-- Spec table
-- Footer (palette + identity)
-- Multi-SKU shared breakdown page
+- Meta header
+- Page 1 (Product render + spec list)
+- Page 2 (Part breakdown)
+- Optional pack overview page (multi-SKU)
 - HTML preview vs. PDF export
 - Editing posture (what is editable, what is not)
 - Approval gating
 
 ## Page geometry
 
-- Aspect ratio: 16:9. Width 1280, height 720 (PDF coordinates). Matches Damien's source deck.
-- Margins: 48px on all sides.
-- Banner height: 80px.
-- Footer height: 110px.
-- Hero region: left half, from below the banner to above the footer.
-- Spec table: right half, same vertical bounds.
+- Aspect ratio: A4 portrait. Width 595, height 842 (PDF coordinates).
+- Margins: 36pt on all sides.
+- Header height: 96pt (holds the 3×3 meta grid).
+- Footer height: 44pt (holds packet notes and the `-- N of M --` page marker).
 
-The PDF (`src/lib/cmf/pdf.ts`) implements these constants. The HTML preview must use the same constants so the preview cannot drift from the final PDF.
+The PDF (`src/lib/cmf/pdf.ts`) implements these constants and exports them as `CMF_PDF_GEOMETRY` for any consumer that needs to mirror the layout. The HTML preview is currently rendered at 16:9 (`CmfDocumentPreviewDialog.tsx`) so designers see roughly the same information density during draft; the PDF is the canonical surface for the designer-facing deliverable.
 
-## Banner
+## Meta header
 
-| Zone | Content |
-|------|---------|
-| Top-left | CMF code (bold), product family (muted, beneath) |
-| Top-centre | Colourway name (primary colour, uppercase) |
-| Top-right | Date (`YYYY-MM-DD`, mono), "Loop · CMF" (bold) |
+A 3×3 grid sits at the top of every page. Cells are LOCK; values change per SKU.
 
-The banner is sticky-feeling: every page in the packet uses the same banner with the SKU's colourway centred. The breakdown page uses "Pack breakdown" as the centre label.
+| Row 1 | Row 2 | Row 3 |
+|-------|-------|-------|
+| CMF number | Collection | Product name |
+| Product code | EAN code | Edit date |
+| Drawn | Checked | Checked |
 
-## Hero region
+Right of the grid: page label ("CMF Page 1" / "Part Break Down Page 2" / "Pack overview") in the primary colour, plus a DRAFT badge when `documentDraft.isDraft` is true.
 
-- Light grey backplate inside the hero rectangle.
-- The approved CMF render is centred and scaled to fit while preserving aspect ratio.
-- No drop shadow, no border around the render itself.
-- If no approved render exists, show a placeholder: "Render not generated yet" (muted, centred).
+## Page 1 (Product render + spec list)
 
-## Spec table
+- Section title: "Product render" (top-left, ink).
+- Hero plate: full-width panel beneath the title, ~45% of inner height. Light grey backplate; the approved render is aspect-preserving fit inside.
+- Component spec list: vertical stack below the hero plate. Each component has a labelled key/value block — Material, Finish, Colour, Artwork — that matches Damien's source template.
+- Placeholder copy when no approved render is bound: "Render not generated yet" (muted, centred).
 
-| Column | Width | Content |
-|--------|-------|---------|
-| Component | 22% | Swatch + label (label uses bold, swatch hex if known) |
-| Pantone / Hex | 22% | Pantone token preferred, hex fallback, "—" when missing |
-| Material | 18% | Material wording verbatim from workbook |
-| Finish | 18% | Finish wording verbatim from workbook |
-| Technique | 20% | Technique wording, muted colour |
+## Page 2 (Part breakdown)
 
-Header row uses uppercase, muted text. Body rows are 22px high. Truncate at column width — never wrap (Operations expects single-line entries). Notes go in the editable preview block, not the spec table.
+- Section title: "Part break down" (top-left, ink).
+- 2-column grid of cards, one per component. Each card shows the component label (primary colour), the swatch chip on the right, and a key/value column on the left with Pantone, Material, Finish, Technique.
+- Cards wrap to additional rows; cells stop drawing when the page footer would collide.
 
-## Footer (palette + identity)
+## Optional pack overview page
 
-Left half: palette swatches with Pantone token underneath each swatch. Auto-laid out 4 per row.
+When the packet has more than one SKU, a final overview page is appended:
 
-Right half (identity column):
+- Same meta header, page label "Pack overview".
+- "Pack breakdown" section title.
+- Grid of SKU cards (2 per row): colourway name (bold, primary), product slug + product code (mono), mini swatch row.
 
-- "Identity" header
-- `Product code  <code>` (mono)
-- `EAN  <ean>` (mono)
-- Packet notes (max width = right column), wrapped
+## Footer
 
-## Multi-SKU shared breakdown page
-
-Added automatically when the packet has more than one SKU. It is a single page summarising every SKU in the packet:
-
-- Banner with "Pack breakdown" centre label.
-- Grid of SKU cards (max 4 per row): colourway name (bold), product slug (mono), mini swatch row (up to 6 component swatches with labels).
-- Packet notes at the bottom, muted, wrapped to full width.
+- 1px hairline at the top of the footer band.
+- Packet notes (when set) wrap inside the left two thirds, muted.
+- Page marker `-- N of M --` on the right (mono), counting every page in the packet including the pack overview.
 
 ## HTML preview vs. PDF export
 
@@ -90,7 +78,7 @@ What this means in practice:
 | SKU ordering inside the packet | Component spec (material, finish, Pantone, technique) |
 | Colourway label override | Components present (add / remove) |
 | Packet notes / packet name | Approved render image (use approve flow instead) |
-| Palette overrides (additional swatches beyond components) | Banner template / layout / aspect ratio |
+| Palette overrides (additional swatches beyond components) | Meta header layout / page geometry |
 
 The editable subset goes through a packet-level `documentDraft` object (see `src/lib/cmf/document.ts`). Workbook edits require re-import.
 
@@ -99,4 +87,4 @@ The editable subset goes through a packet-level `documentDraft` object (see `src
 Final PDF export is gated on every SKU having an approved render attempt.
 
 - "Generate PDF" disabled until all SKUs have approvals.
-- If `documentDraft` opts a SKU into "draft override" (showing a chosen attempt without approving), the export shows a warning watermark with `DRAFT` ribbon and the export filename gains a `_DRAFT` suffix. Use sparingly — most CMF reviews want clean approval-gated PDFs.
+- If `documentDraft` opts a SKU into "draft override" (showing a chosen attempt without approving), the export draws a DRAFT badge next to each page label and the filename gains a `_DRAFT` suffix. Use sparingly — most CMF reviews want clean approval-gated PDFs.

--- a/tests/cmf-pdf.spec.ts
+++ b/tests/cmf-pdf.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test'
-import { buildCmfPacketPdf } from '../src/lib/cmf/pdf'
+import { PDFDocument } from 'pdf-lib'
+import { buildCmfPacketPdf, CMF_PDF_GEOMETRY } from '../src/lib/cmf/pdf'
 
 /**
  * Smoke test for the CMF PDF builder. We don't try to compare visual output —
@@ -71,4 +72,74 @@ test('buildCmfPacketPdf adds a breakdown page for multi-SKU packets', async () =
   })
   expect(pdf.length).toBeGreaterThan(500)
   expect(pdfHeader(pdf)).toBe('%PDF-')
+})
+
+/* ── Source-template structure (Damien's Loop CMF deck) ─────────────── */
+
+test('buildCmfPacketPdf renders A4 portrait pages, matching the source CMF deck', async () => {
+  const pdf = await buildCmfPacketPdf({
+    packetName: 'Switch 2 Emerald',
+    cmfCode: 'CMF-001234revA',
+    notes: null,
+    renders: [SINGLE_RENDER as any],
+  })
+  const doc = await PDFDocument.load(pdf)
+  const page = doc.getPage(0)
+  const size = page.getSize()
+  // A4 portrait: 595 × 842 pt — Damien's source template orientation.
+  expect(Math.round(size.width)).toBe(CMF_PDF_GEOMETRY.PAGE_W)
+  expect(Math.round(size.height)).toBe(CMF_PDF_GEOMETRY.PAGE_H)
+  expect(size.height).toBeGreaterThan(size.width)
+})
+
+test('buildCmfPacketPdf produces two pages per SKU (render + part breakdown)', async () => {
+  const pdf = await buildCmfPacketPdf({
+    packetName: 'Switch 2 Emerald',
+    cmfCode: 'CMF-001234revA',
+    notes: null,
+    renders: [SINGLE_RENDER as any],
+  })
+  const doc = await PDFDocument.load(pdf)
+  expect(doc.getPageCount()).toBe(2)
+})
+
+test('buildCmfPacketPdf appends a pack overview page for multi-SKU packets', async () => {
+  const renders = [
+    SINGLE_RENDER,
+    {
+      ...SINGLE_RENDER,
+      id: '00000000-0000-0000-0000-000000000002',
+      label: 'Switch 2 Gold',
+      colorwayName: 'Gold',
+    },
+  ]
+  const pdf = await buildCmfPacketPdf({
+    packetName: 'Switch 2 Spring 2026',
+    cmfCode: 'CMF-001234revA',
+    notes: null,
+    renders: renders as any,
+  })
+  const doc = await PDFDocument.load(pdf)
+  // 2 SKUs × 2 template pages + 1 pack overview = 5
+  expect(doc.getPageCount()).toBe(5)
+})
+
+test('buildCmfPacketPdf stays portrait for every page even with many SKUs', async () => {
+  const renders = Array.from({ length: 3 }).map((_, i) => ({
+    ...SINGLE_RENDER,
+    id: `00000000-0000-0000-0000-00000000000${i + 1}`,
+    label: `Switch 2 #${i + 1}`,
+    colorwayName: `Way ${i + 1}`,
+  }))
+  const pdf = await buildCmfPacketPdf({
+    packetName: 'Switch 2 Trio',
+    cmfCode: 'CMF-001234revA',
+    notes: null,
+    renders: renders as any,
+  })
+  const doc = await PDFDocument.load(pdf)
+  for (let i = 0; i < doc.getPageCount(); i++) {
+    const { width, height } = doc.getPage(i).getSize()
+    expect(height).toBeGreaterThan(width)
+  }
 })

--- a/tests/cmf-products.spec.ts
+++ b/tests/cmf-products.spec.ts
@@ -93,3 +93,28 @@ test('safeFileSlug strips path-traversal and special characters', () => {
   )
   expect(safeFileSlug('  spaces  ')).toBe('spaces')
 })
+
+/**
+ * Pins the property the import API relies on when it surfaces a multi-
+ * product import like Damien's Switch 2 + Cocoon workbook:
+ *
+ *   const productName = getCmfProduct(productSlug)?.name ?? null
+ *
+ * If a future catalog edit drops the `name` field for any product, the
+ * import UI silently regresses to slug-only labels. This test catches that
+ * before users do.
+ */
+test('every catalog product exposes a non-empty display name for the import summary', () => {
+  for (const product of listCmfProducts()) {
+    expect(typeof product.name).toBe('string')
+    expect(product.name.trim().length).toBeGreaterThan(0)
+    expect(getCmfProduct(product.slug)?.name).toBe(product.name)
+  }
+})
+
+test('getCmfProduct resolves the Switch 2 + Cocoon pair Damien exercised in the multi-product workbook', () => {
+  const switch2 = getCmfProduct('switch2')
+  const cocoon = getCmfProduct('cocoon')
+  expect(switch2?.name).toBe('Loop Switch 2')
+  expect(cocoon?.name).toBe('Loop Cocoon')
+})

--- a/tests/cmf-prompt.spec.ts
+++ b/tests/cmf-prompt.spec.ts
@@ -207,3 +207,154 @@ test('buildPacketFileSlug matches the requested CMF naming pattern', () => {
   })
   expect(slug).toBe('CMF-001234revA_LoopSwitch2_CMF_Sage')
 })
+
+/* ── Clown region addressing ──────────────────────────────────────────── */
+
+test('buildCmfPrompt anchors component lines on the clown reference colour when metadata is available', () => {
+  const result = buildCmfPrompt(FIXTURE, {
+    clownComponents: [
+      { region: 'pom_ring', label: 'POM ring', colorHex: '#ff3344' },
+      { region: 'cosmetic_cap', label: 'Cosmetic cap', colorHex: '#3366ff' },
+    ],
+  })
+
+  // POM ring is anchored to "red" (#ff3344) and Cosmetic cap to "blue" (#3366ff).
+  expect(result.componentLines[0]).toContain('POM ring (the red surface on the reference)')
+  expect(result.componentLines[1]).toContain('Cosmetic cap (the blue surface on the reference)')
+
+  // The reference legend appears once, with both entries.
+  expect(result.basePrompt).toContain('Clown reference legend')
+  expect(result.basePrompt).toContain('red → POM ring')
+  expect(result.basePrompt).toContain('blue → Cosmetic cap')
+})
+
+test('buildCmfPrompt falls back to label-only addressing when no clown metadata is given', () => {
+  const result = buildCmfPrompt(FIXTURE)
+  // No "on the reference" qualifier and no legend line.
+  expect(result.componentLines[0]).not.toContain('on the reference')
+  expect(result.basePrompt).not.toContain('Clown reference legend')
+})
+
+test('buildCmfPrompt skips clown legend entries without a colour hex', () => {
+  const result = buildCmfPrompt(FIXTURE, {
+    clownComponents: [
+      { region: 'pom_ring', label: 'POM ring', colorHex: null },
+      { region: 'cosmetic_cap', label: 'Cosmetic cap' },
+    ],
+  })
+  expect(result.basePrompt).not.toContain('Clown reference legend')
+  expect(result.componentLines[0]).not.toContain('surface on the reference')
+})
+
+/* ── Palette context ──────────────────────────────────────────────────── */
+
+test('buildCmfPrompt surfaces palette context when palette swatches are supplied', () => {
+  const result = buildCmfPrompt({
+    ...FIXTURE,
+    palette: [
+      { label: 'Accent', pantone: 'PANTONE 7720 C' },
+      { label: 'Lining', colorHex: '#3366ff' },
+    ],
+  })
+  expect(result.basePrompt).toContain('Overall CMF palette context')
+  expect(result.basePrompt).toContain('Accent → PANTONE 7720 C')
+  expect(result.basePrompt).toContain('Lining → #3366ff')
+  // Palette is context, not extra surfaces — make sure the prompt says so.
+  expect(result.basePrompt).toContain('not extra surfaces to recolour')
+})
+
+test('buildCmfPrompt omits palette block when no swatches are supplied', () => {
+  const result = buildCmfPrompt(FIXTURE)
+  expect(result.basePrompt).not.toContain('Overall CMF palette context')
+})
+
+/* ── Material / finish vocabulary for Damien's Switch 2 pack ──────────── */
+
+test('buildCmfPrompt promotes matte POM with the deep-matte engineering wording', () => {
+  const result = buildCmfPrompt({
+    ...FIXTURE,
+    components: [
+      {
+        region: 'pom_ring',
+        label: 'POM ring',
+        pantone: 'Pantone 7720C',
+        material: 'POM',
+        finish: 'Matte',
+      },
+    ],
+  })
+  expect(result.componentLines[0].toLowerCase()).toContain('deeply matte engineering plastic')
+  expect(result.componentLines[0].toLowerCase()).toContain('completely diffuse')
+})
+
+test('buildCmfPrompt distinguishes glossy ABS from NCVM metallic on ABS', () => {
+  const glossy = buildCmfPrompt({
+    ...FIXTURE,
+    components: [
+      {
+        region: 'cosmetic_cap',
+        label: 'Cosmetic cap',
+        pantone: 'Pantone 155C',
+        material: 'ABS',
+        finish: 'glossy',
+      },
+    ],
+  })
+  const ncvm = buildCmfPrompt({
+    ...FIXTURE,
+    components: [
+      {
+        region: 'cosmetic_cap',
+        label: 'Cosmetic cap',
+        pantone: 'Pantone 155C',
+        material: 'ABS',
+        finish: 'NCVM Satin',
+      },
+    ],
+  })
+  expect(glossy.componentLines[0].toLowerCase()).toContain('high-gloss')
+  expect(glossy.componentLines[0].toLowerCase()).toContain('clearly a polished plastic')
+  expect(ncvm.componentLines[0].toLowerCase()).toContain('ncvm-coated')
+  expect(ncvm.componentLines[0].toLowerCase()).toContain('anodised aluminium')
+})
+
+test('buildCmfPrompt expands VDI 21 into deep matte injection-mould vocabulary', () => {
+  const result = buildCmfPrompt({
+    ...FIXTURE,
+    components: [
+      {
+        region: 'nozzle_piece',
+        label: 'Nozzle piece + retention ring',
+        pantone: 'Pantone 726C',
+        material: 'ABS',
+        finish: 'VDI 21',
+      },
+    ],
+  })
+  expect(result.componentLines[0]).toContain('VDI 21')
+  expect(result.componentLines[0].toLowerCase()).toContain('deep matte')
+  expect(result.componentLines[0].toLowerCase()).toContain('injection-mould grain')
+})
+
+test('buildCmfPrompt translates "Milky see through 30%" into a calibrated translucent silicone clause', () => {
+  const result = buildCmfPrompt({
+    ...FIXTURE,
+    components: [
+      {
+        region: 'eartip',
+        label: 'Eartip (hidden flange)',
+        pantone: 'Pantone 7720C',
+        material: 'Silicone',
+        finish: 'Milky see through 30%',
+      },
+    ],
+  })
+  expect(result.componentLines[0].toLowerCase()).toContain('30% light transmission')
+  expect(result.componentLines[0].toLowerCase()).toContain('frosted appearance')
+  expect(result.componentLines[0].toLowerCase()).not.toContain('roughly 100% light transmission')
+})
+
+test('buildCmfPrompt ends with a material-fidelity quality bar so finish stays first-class', () => {
+  const result = buildCmfPrompt(FIXTURE)
+  expect(result.basePrompt).toContain('Material fidelity is critical')
+})

--- a/tests/cmf-xlsx.spec.ts
+++ b/tests/cmf-xlsx.spec.ts
@@ -145,3 +145,80 @@ test('normaliseParsedSheets produces validated CmfSkuRows', () => {
   expect(switch2Row.cmfCode).toBe('CMF-001234revA')
   expect(switch2Row.components.length).toBeGreaterThanOrEqual(2)
 })
+
+/* ── Multi-product (Damien's Switch 2 + Cocoon ask) ──────────────────── */
+
+/**
+ * Damien asked: "what if I filled the Switch 2 + Cocoon in my Excel for
+ * example? Because I have the feeling it's product per product the render
+ * generation". The data flow is intentionally product-per-packet — a
+ * single workbook with both tabs produces one packet per product, each
+ * scoped to that product's SKUs. This fixture pins that property at the
+ * parser/normaliser level so future changes don't quietly collapse the
+ * two products into one packet.
+ */
+function buildSwitch2PlusCocoonFixture(): Buffer {
+  const switch2 = [
+    ['', 'Common specs', 'SKU 1'],
+    ['BANNER', '', ''],
+    ['CMF number', '', 'CMF-001234revA'],
+    ['Collection', 'Switch 2', ''],
+    ['Product Name', '', 'Switch 2 Emerald'],
+    ['Product Code', '', 'en-sw-emb-02'],
+    ['POM RING', '', ''],
+    ['Material', 'POM', ''],
+    ['Finish', 'Matte', ''],
+    ['Colour', '', 'Pantone 7720C'],
+  ]
+  const cocoon = [
+    ['', 'Common specs', 'SKU 1'],
+    ['BANNER', '', ''],
+    ['CMF number', '', 'CMF-002000revA'],
+    ['Collection', 'Cocoon', ''],
+    ['Product Name', '', 'Cocoon Berry'],
+    ['Product Code', '', 'cc-ber-01'],
+    ['EAR CUSHION', '', ''],
+    ['Material', 'Fabric', ''],
+    ['Finish', 'Soft', ''],
+    ['Colour', '', 'Pantone 1777C'],
+    ['FOAM', '', ''],
+    ['Material', 'PU foam', ''],
+    ['Colour', '', 'Black'],
+  ]
+  const wb = XLSX.utils.book_new()
+  XLSX.utils.book_append_sheet(wb, XLSX.utils.aoa_to_sheet(switch2), 'Switch 2')
+  XLSX.utils.book_append_sheet(wb, XLSX.utils.aoa_to_sheet(cocoon), 'Cocoon')
+  const out = XLSX.write(wb, { type: 'buffer', bookType: 'xlsx' })
+  return Buffer.isBuffer(out) ? out : Buffer.from(out)
+}
+
+test('a Switch 2 + Cocoon workbook produces one normalised row per product', () => {
+  const buffer = buildSwitch2PlusCocoonFixture()
+  const parsed = parseCmfWorkbook(buffer)
+  expect(parsed.format).toBe('transposed')
+  expect(parsed.sheets.map((s) => s.productSlug).sort()).toEqual(['cocoon', 'switch2'])
+
+  const result = normaliseParsedSheets(parsed.sheets)
+  expect(result.errors).toHaveLength(0)
+  // One row per product (one filled SKU column on each tab).
+  expect(result.rows).toHaveLength(2)
+  const slugs = result.rows.map((r) => r.productSlug).sort()
+  expect(slugs).toEqual(['cocoon', 'switch2'])
+})
+
+test('bucketing rows by productSlug preserves the multi-product split that createPacketFromRows relies on', () => {
+  // The packet creator groups by `productSlug` into one packet per product.
+  // Replicate that grouping here so the property stays explicitly tested
+  // without dragging Prisma into a unit test.
+  const buffer = buildSwitch2PlusCocoonFixture()
+  const parsed = parseCmfWorkbook(buffer)
+  const result = normaliseParsedSheets(parsed.sheets)
+
+  const buckets = new Map<string, number>()
+  for (const row of result.rows) {
+    buckets.set(row.productSlug, (buckets.get(row.productSlug) ?? 0) + 1)
+  }
+  expect(buckets.size).toBe(2)
+  expect(buckets.get('switch2')).toBe(1)
+  expect(buckets.get('cocoon')).toBe(1)
+})


### PR DESCRIPTION
## Summary

Addresses Damien's CMF tool feedback by closing three gaps:

- **Multi-product imports** now surface every created packet (one per product slug), with a clickable list and a "Created N product packets: Switch 2, Cocoon" summary, so a Switch 2 + Cocoon workbook no longer feels product-by-product.
- **Render prompts** address components by clown reference colour ("the orange surface on the reference (Cosmetic cap): ...") when clown metadata is available, fold palette swatches into the prompt as colour-harmony context, and use stronger material/finish vocabulary for matte POM, glossy ABS vs NCVM-coated ABS, VDI 21, and "Milky see through 30%" silicone.
- **PDF export** mirrors Damien's source CMF deck: A4 portrait, two pages per SKU (CMF spec + Part breakdown), 3×3 identity header (CMF number / Collection / Product name / Product code / EAN / Edit date / Drawn / Checked / Checked), plus a pack overview page for multi-SKU packets. Draft watermark renders on every page when the export is gated.

## What's in scope

- `src/app/api/cmf/import/route.ts` — packets array now carries `productName`.
- `src/components/cmf/CmfImportPanel.tsx`, `src/hooks/useCmf.ts` — surface every created packet, link to each.
- `src/lib/cmf/prompt.ts`, `src/lib/cmf/render.ts` — clown legend, palette context, material fidelity bar, peek-clown helper.
- `src/lib/cmf/pdf.ts`, `src/app/api/cmf/packets/[id]/pdf/route.ts` — rewritten to A4 portrait template with 3×3 identity header and breakdown page.
- `src/lib/skills/loop-cmf-generation/references/document-template.md` — docs updated to match the new template.
- `tests/cmf-prompt.spec.ts`, `tests/cmf-pdf.spec.ts`, `tests/cmf-products.spec.ts`, `tests/cmf-xlsx.spec.ts` — 13 new tests pinning the new behavior.

## Test plan

- [x] `npx playwright test tests/cmf-prompt.spec.ts tests/cmf-pdf.spec.ts tests/cmf-products.spec.ts tests/cmf-xlsx.spec.ts tests/cmf-schema.spec.ts tests/cmf-document.spec.ts` — 61 passed locally.
- [x] `npx tsc --noEmit` — clean.
- [ ] Import the Switch 2 + Cocoon workbook end-to-end; confirm both packets show up in the importer with the new product list.
- [ ] Generate a Switch 2 Emerald render with a clown that has region colours; confirm the prompt includes the clown legend and that material/finish reads correctly.
- [ ] Export an approved Switch 2 PDF; confirm A4 portrait, 2 pages per SKU, identity header matching the source deck.

## Notes for review

- The clown-legend addressing is opt-in: if the resolved clown's `components` JSON has no `color_hex`, the prompt falls back to label-only addressing exactly as before.
- The new PDF page count for a single-SKU packet is **2** (was 1) and for an N-SKU packet is **N×2 + 1**. Tests updated accordingly.
- The HTML preview component (`CmfDocumentPreviewDialog.tsx`) still renders 16:9; the PDF is the canonical designer surface. Bringing the preview into line with the new template is a sensible follow-up.

Made with [Cursor](https://cursor.com)